### PR TITLE
Exists stability and improved unapply

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ import skolems._
 
 def foo(unapplied: List[∃[λ[α => (α, α => String)]]]): List[String] =
   unapplied map { u =>
-    val (v, f) = u()
+    val (v, f) = u.value
     f(v)
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@
 
 name := "skolems"
 
-ThisBuild / baseVersion := "0.1"
+ThisBuild / baseVersion := "0.2"
 
 ThisBuild / organization := "com.codecommit"
 ThisBuild / publishGithubUser := "djspiewak"

--- a/src/main/scala/skolems/Exists.scala
+++ b/src/main/scala/skolems/Exists.scala
@@ -18,7 +18,7 @@ package skolems
 
 trait Exists[+F[_]] {
   type A
-  def apply(): F[A]
+  val value: F[A]
 }
 
 object Exists {
@@ -35,12 +35,12 @@ object Exists {
     def apply[A0](fa: F[A0]): Exists[F] =
       new Exists[F] {
         type A = A0
-        def apply() = fa
+        val value = fa
       }
   }
 
   def unapply[F[_]](ef: Exists[F]): Some[F[ef.A]] =
-    Some(ef())
+    Some(ef.value)
 
   /**
    * Tricksy overload for when you want everything to "just work(tm)".
@@ -55,7 +55,7 @@ object Exists {
   implicit def coerce[F[_], A](F: F[A]): Exists[F] = apply(F)
 
   def raise[F[_], B](f: Exists[λ[α => F[α] => B]]): ∀[F] => B =
-    af => f()(af[f.A])
+    af => f.value(af[f.A])
 
   // This cast is required because Scala's type inference will not allow
   // the parameter from the ∀ invocation (which is unreferenceable) to
@@ -66,7 +66,7 @@ object Exists {
     Exists[λ[α => F[α] => B]]((fa: F[Any]) => f(∀[F](fa.asInstanceOf)))
 
   def lowerE[F[_], B](f: ∀[F] => B): (F[A] => B) forSome { type A } =
-    lower[F, B](f)()
+    lower[F, B](f).value
 
   /**
    * Utilities to implicitly materialize native `forSome` contexts.

--- a/src/main/scala/skolems/Exists.scala
+++ b/src/main/scala/skolems/Exists.scala
@@ -39,7 +39,7 @@ object Exists {
       }
   }
 
-  def unapply[F[_]](ef: Exists[F]): Some[F[ef.A]] =
+  def unapply[F[_]](ef: Exists[F]): Some[F[A] forSome { type A }] =
     Some(ef.value)
 
   /**

--- a/src/main/scala/skolems/Forall.scala
+++ b/src/main/scala/skolems/Forall.scala
@@ -55,7 +55,7 @@ object Forall {
     apply(ft).asInstanceOf[T]
 
   def raise[F[_], B](f: Forall[λ[α => F[α] => B]]): ∃[F] => B =
-    ef => f[ef.A](ef())
+    ef => f[ef.A](ef.value)
 
   def lower[F[_], B](f: ∃[F] => B): Forall[λ[α => F[α] => B]] =
     Forall[λ[α => F[α] => B]](fa => f(∃[F](fa)))


### PR DESCRIPTION
Making the existential value a `val` instead of a `def` makes it stable which seems useful, though I don't have concrete example for where it'd be necessary.

Changing the unapply return type allows pattern matching to work in the case where `F[_]` is a GADT.