### PR TITLE
Spport type constructor with 2 holes

### DIFF
--- a/src/main/scala/skolems/Exists2.scala
+++ b/src/main/scala/skolems/Exists2.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package skolems
+
+trait Exists2[+F[_,_]] {
+  type A
+  type A2
+  val value: F[A,A2]
+}
+
+object Exists2 {
+
+  /**
+   * A forgetful constructor which packs a concrete value into an existential.
+   * This is mostly useful for explicitly assisting the compiler in sorting all
+   * of this out.
+   */
+  def apply[F[_,_]]: PartiallyApplied[F] =
+    new PartiallyApplied[F]
+
+  final class PartiallyApplied[F[_,_]] {
+    def apply[A0,A20](fa: F[A0,A20]): Exists2[F] =
+      new Exists2[F] {
+        type A = A0
+        type A2 = A20
+        val value = fa
+      }
+  }
+
+  def unapply[F[_,_]](ef: Exists2[F]): Some[F[A,A2] forSome { type A; type A2 }] =
+    Some(ef.value)
+
+  /**
+   * Tricksy overload for when you want everything to "just work(tm)".
+   * The implicit modifiers are to allow the compiler to materialize
+   * things through implicit search when relevant; don't be afraid to
+   * call this function explicitly.
+   */
+  implicit def apply[F[_,_], A, A2](implicit fa: F[A,A2]): Exists2[F] =
+    apply[F](fa)
+
+  // non-implicit parameter version designed to provide nicer syntax
+  implicit def coerce[F[_,_], A, A2](F: F[A,A2]): Exists2[F] = apply(F)
+
+  def raise[F[_,_], B](f: Exists2[λ[(α,α2) => F[α,α2] => B]]): ∀∀[F] => B =
+    af => f.value(af[f.A,f.A2])
+
+  // This cast is required because Scala's type inference will not allow
+  // the parameter from the ∀ invocation (which is unreferenceable) to
+  // flow "outward" and form the constrained input type of the function.
+  // So because we don't have non-local inference in Scala, we need to
+  // play tricks with erasure and cast from F[Any].
+  def lower[F[_,_], B](f: ∀∀[F] => B): Exists2[λ[(α,α2) => F[α,α2] => B]] =
+    Exists2[λ[(α,α2) => F[α,α2] => B]]((fa: F[Any,Any]) => f(∀∀[F](fa.asInstanceOf)))
+
+  def lowerE[F[_,_], B](f: ∀∀[F] => B): (F[A,A2] => B) forSome { type A; type A2 } =
+    lower[F, B](f).value
+
+  /**
+   * Utilities to implicitly materialize native `forSome` contexts.
+   */
+  /*object Implicits {
+    implicit def materialize[F[_]](implicit F: Exists[F]): F[A] forSome { type A } = F()
+  }*/
+}

--- a/src/main/scala/skolems/Forall2.scala
+++ b/src/main/scala/skolems/Forall2.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package skolems
+
+import scala.annotation.unchecked.uncheckedVariance
+
+private[skolems] sealed trait Parent2 {
+  private[skolems] type Apply[A,B]
+}
+
+trait Forall2[+F[_,_]] extends Parent2 { outer =>
+  private[skolems] type Apply[A,B] = F[A,B] @uncheckedVariance
+  def apply[A,B]: F[A,B]
+}
+
+object Forall2 {
+  // cannot be referenced outside of Forall2
+  private[Forall2] type τ
+  private[Forall2] type τ2
+
+  /**
+   * This function is intended to be invoked explicitly, the implicit
+   * modifiers are simply because the compiler can infer this in many
+   * cases. For example:
+   *
+   * implicit def eitherMonad[A]: Monad[Either[A, ?]] = ???
+   *
+   * implicitly[∀[α => Monad[Either[α, ?]]]]
+   *
+   * The above will work.
+   */
+  def apply[F[_,_]](ft: F[τ,τ2]): Forall2[F] =
+    new Forall2[F] {
+      def apply[A,B] = ft.asInstanceOf[F[A,B]]
+    }
+
+  /**
+   * This is the implicit version of apply, but restructured and encoded
+   * such that the F is unconstrained in in arity or fixity.
+   */
+  implicit def materialize[T <: Parent2](implicit ft: T#Apply[τ,τ2]): T =
+    apply(ft).asInstanceOf[T]
+
+  def raise[F[_,_], B](f: Forall2[λ[(α,α2) => F[α,α2] => B]]): ∃∃[F] => B =
+    ef => f[ef.A,ef.A2](ef.value)
+
+  def lower[F[_,_], B](f: ∃∃[F] => B): Forall2[λ[(α,α2) => F[α,α2] => B]] =
+    Forall2[λ[(α,α2) => F[α,α2] => B]](fa => f(∃∃[F](fa)))
+
+  def lowerA[F[_,_], B, C]: PartiallyAppliedLowerA[F, B, C] =
+    new PartiallyAppliedLowerA[F, B, C]
+
+  final class PartiallyAppliedLowerA[F[_,_], B, C] {
+    def apply[A,A2](f: ∃∃[F] => B): F[A,A2] => B =
+      lower[F, B](f)[A,A2]
+  }
+
+  /**
+   * Utilities to implicitly materialize let-bound polymorphic contexts.
+   */
+  /*object Implicits {
+    implicit def materializeUnification[P <: Parent2, A, E](
+        implicit P: P,
+        ev: P#Apply[E] <:< A): A =
+      ev(P.asInstanceOf[Forall2[P.Apply]][E])
+  }*/
+}

--- a/src/main/scala/skolems/package.scala
+++ b/src/main/scala/skolems/package.scala
@@ -18,6 +18,12 @@ package object skolems {
   type ∀[+F[_]] = Forall[F]
   val ∀ = Forall
 
+  type ∀∀[+P[_,_]] = Forall2[P]
+  val ∀∀ = Forall2
+
   type ∃[+F[_]] = Exists[F]
   val ∃ = Exists
+
+  type ∃∃[+P[_,_]] = Exists2[P]
+  val ∃∃ = Exists2
 }

--- a/src/test/scala/Forall2Tes.scala
+++ b/src/test/scala/Forall2Tes.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import skolems.∀∀
+
+class Forall2Tes {
+  trait Profunctor[=>:[_, _]] {
+    def dimap[S,T,A,B](sa: S => A, bt: B => T): A =>: B => S =>: T
+  }
+
+  type Optics[P[_, _],S,T,A,B] = P[A,B] => P[S,T]
+  type S = Int
+  type T = Int
+  type A = Int
+  type B = Int
+  type Iso1[P[_,_]] = Profunctor[P] => Optics[P,S,T,A,B]
+  type Iso2[P[_,_]] = ∀∀[Iso1]
+
+  //type Iso3[S,T,A,B] = ∀∀[λ[P => Profunctor[P] => Optics[P,S,T,A,B]]]
+}
+
+

--- a/src/test/scala/ForallTest.scala
+++ b/src/test/scala/ForallTest.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2019 Daniel Spiewak
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import skolems.∀
+
+class ForallTest {
+  def bippy(s: String, i: Int, f: ∀[λ[α => α => List[α]]]): (List[String], List[Int]) =
+    (f[String](s), f[Int](i))
+}


### PR DESCRIPTION
Expanded on work in https://github.com/lemastero/skolems/pull/1 to support :
```
  trait Profunctor[=>:[_, _]] {
    def dimap[S,T,A,B](sa: S => A, bt: B => T): A =>: B => S =>: T
  }

  type Optic[P[_, _],S,T,A,B] = P[A,B] => P[S,T]
  type Iso[S,T,A,B] = ∀∀[λ[P[_,_] => Profunctor[P] => Optic[P,S,T,A,B]]]
```
This fixes #6